### PR TITLE
FIX: Serialization Error when the value is an empty string

### DIFF
--- a/lib/mysql-binuuid/type.rb
+++ b/lib/mysql-binuuid/type.rb
@@ -27,7 +27,8 @@ module MySQLBinUUID
     # Invoked when the provided value needs to be serialized before storing
     # it to the database.
     def serialize(value)
-      return if value.nil?
+      return if value.blank?
+
       undashed_uuid = strip_dashes(value)
 
       # To avoid SQL injection, verify that it looks like a UUID. ActiveRecord


### PR DESCRIPTION
When we have nil for a foreign key, Rails converts it to an empty string before assigning the attributes to the model and hence it sends an empty string for serialization.
This returns `MySQLBinUUID::InvalidUUID, "#{value} is not a valid UUID"`, and this PR aims to fix that.